### PR TITLE
Using proguard to strip redundant classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: android
 
 android:
   components:
-    - build-tools-23.0.1
+    - tools
+    - build-tools-23.0.2
     - android-23
     - extra-google-google_play_services
     - extra-android-support
@@ -18,7 +19,7 @@ env:
     - ANDROID_TARGET=android-23  ANDROID_ABI=armeabi-v7a
 
 before_install:
-  - echo yes | android update sdk --all --filter build-tools-22.0.1 --no-ui --force
+  - echo yes | android update sdk --all --filter build-tools-23.0.1 --no-ui --force
 
 before_script:
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath"org.jacoco:org.jacoco.core:0.7.4.201502262128"
     }
 }
 
@@ -44,8 +45,9 @@ allprojects {
 ext {
     minSdk = 14
     targetSdk = 23
-    buildToolsVersion = '23.0.1'
+    buildToolsVersion = '23.0.2'
     compileSdkVersion = 23
     versionCode = 2
     versionName = "1.1"
+    supportLibVersion = '23.1.1'  // variable that can be referenced to keep support libs consistent
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -27,6 +27,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:support-v4:23.1.1'
+    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    compile "com.android.support:support-v4:${rootProject.ext.supportLibVersion}"
 }

--- a/demo/src/main/res/layout/activity_demo.xml
+++ b/demo/src/main/res/layout/activity_demo.xml
@@ -60,6 +60,7 @@
 
                     <EditText
                         android:id="@+id/edt_ip"
+                        android:inputType="numberDecimal"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxLines="1"
@@ -68,6 +69,7 @@
 
                     <EditText
                         android:id="@+id/edt_tel"
+                        android:inputType="phone"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxLines="1"
@@ -79,6 +81,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxLines="1"
+                        android:inputType="number"
                         android:singleLine="true"
                         android:hint="@string/edt_zipcode"/>
 
@@ -87,12 +90,13 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxLines="1"
+                        android:inputType="number"
                         android:singleLine="true"
                         android:hint="@string/edt_year"/>
 
                     <EditText
                         android:id="@+id/edt_height"
-                        android:inputType="numberDecimal"
+                        android:inputType="number"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:maxLines="1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -17,7 +17,8 @@ android {
         }
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro'
         }
     }
     sourceSets {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,8 +16,8 @@ android {
             testCoverageEnabled true
         }
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard-rules.pro'
         }
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,14 +34,10 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
-    jacoco {
-        version = '0.7.5.201505241946'
-    }
 }
 
 dependencies {
-    compile 'com.google.guava:guava:18.0'
-
+    compile 'com.google.guava:guava:19.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:2.0.+'
     testCompile 'org.easymock:easymock:3.4'

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+ -keep class com.google.common.collect.Range
+ -keep class com.basgeekball.awesomevalidation.** { *; }


### PR DESCRIPTION
addresses issue #17 . Using proguard strip everything out except the Range class of guava and the classes from the library