### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 env:
   global:
-    - GRADLE_OPTS='-Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dkotlin.incremental=false -DdisablePreDex'
+    - GRADLE_OPTS='-Dorg.gradle.daemon=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -DdisablePreDex'
     - ANDROID_TARGET=30
     - ANDROID_BUILD_TOOLS_VERSION=30.0.2
     - ANDROID_ABI=armeabi-v7a


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
